### PR TITLE
Use Spring Cloud Stream 1.1.0.RELEASE/Brooklyn for a more stable base.

### DIFF
--- a/demos/demo-receiver/pom.xml
+++ b/demos/demo-receiver/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.6.RELEASE</version>
+        <version>1.4.0.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -30,19 +30,13 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>za.co.absa</groupId>
             <artifactId>spring-cloud-starter-stream-ibmmq</artifactId>
             <version>1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 
@@ -54,42 +48,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/demos/demo-receiver/src/main/java/za/co/absa/demo/receiver/ToUpperStringTransformer.java
+++ b/demos/demo-receiver/src/main/java/za/co/absa/demo/receiver/ToUpperStringTransformer.java
@@ -4,7 +4,8 @@
 
 package za.co.absa.demo.receiver;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -16,20 +17,17 @@ import org.springframework.messaging.handler.annotation.SendTo;
 @EnableBinding(Processor.class)
 public class ToUpperStringTransformer {
 
-    public static void main(final String[] args) {
-        SpringApplication.run(ToUpperStringTransformer.class, args);
-    }
-
-    /**
-     * The log4j logger.
-     */
-    private static final Logger LOG = Logger.getLogger(ToUpperStringTransformer.class);
+    private static final Logger log = LoggerFactory.getLogger(ToUpperStringTransformer.class);
 
     @StreamListener(Processor.INPUT)
     @SendTo(Processor.OUTPUT)
     public String toUpperString(final String str) {
         final String processed = str.toUpperCase();
-        LOG.info("Upper: " + processed);
+        log.info("Upper: " + processed);
         return processed;
+    }
+
+    public static void main(final String[] args) {
+        SpringApplication.run(ToUpperStringTransformer.class, args);
     }
 }

--- a/demos/demo-receiver/src/main/resources/application.properties
+++ b/demos/demo-receiver/src/main/resources/application.properties
@@ -5,7 +5,6 @@
 spring.cloud.stream.bindings.input.destination=demo1.randomstring
 spring.cloud.stream.bindings.output.destination=demo1.upperstring
 
-
 spring.ibmmq.host=172.17.0.2
 spring.ibmmq.port=1414
 spring.ibmmq.qm=QM1
@@ -13,11 +12,9 @@ spring.ibmmq.username=scs
 spring.ibmmq.password=scs
 spring.ibmmq.channel=SPRING.JMS.SVRCONN
 
-
 spring.cloud.stream.ibmmq.binder.default-destination-type=topic
-
-spring.cloud.stream.bindings.input.consumer.partitioned=true
-spring.cloud.stream.instance-count=5
+#spring.cloud.stream.bindings.input.consumer.partitioned=true
+#spring.cloud.stream.instance-count=5
 
 
 

--- a/demos/demo-receiver/src/main/resources/log4j.properties
+++ b/demos/demo-receiver/src/main/resources/log4j.properties
@@ -1,9 +1,0 @@
-#
-# Copyright (C) 2016 TopCoder Inc., All Rights Reserved
-#
-
-log4j.rootLogger=DEBUG, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %m %n

--- a/demos/demo-sender/pom.xml
+++ b/demos/demo-sender/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.6.RELEASE</version>
+        <version>1.4.0.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -30,24 +30,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>za.co.absa</groupId>
             <artifactId>spring-cloud-starter-stream-ibmmq</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>org.springframework.cloud</groupId>-->
-            <!--<artifactId>spring-cloud-starter-stream-rabbit</artifactId>-->
-            <!--<version>1.0.2.RELEASE</version>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 
@@ -59,42 +53,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/demos/demo-sender/src/main/java/za/co/absa/demo/sender/RandomStringGenerator.java
+++ b/demos/demo-sender/src/main/java/za/co/absa/demo/sender/RandomStringGenerator.java
@@ -5,7 +5,8 @@
 package za.co.absa.demo.sender;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -19,11 +20,7 @@ import org.springframework.messaging.support.GenericMessage;
 @EnableBinding(Source.class)
 public class RandomStringGenerator {
 
-    public static void main(final String[] args) {
-        SpringApplication.run(RandomStringGenerator.class, args);
-    }
-
-    private static final Logger log = Logger.getLogger(RandomStringGenerator.class);
+    private static final Logger log = LoggerFactory.getLogger(RandomStringGenerator.class);
 
     private volatile int messageCounter = 0;
 
@@ -35,5 +32,9 @@ public class RandomStringGenerator {
             log.info("Random: " + random);
             return new GenericMessage<>(random);
         };
+    }
+
+    public static void main(final String[] args) {
+        SpringApplication.run(RandomStringGenerator.class, args);
     }
 }

--- a/demos/demo-sender/src/main/resources/application.properties
+++ b/demos/demo-sender/src/main/resources/application.properties
@@ -4,7 +4,6 @@
 
 spring.cloud.stream.bindings.output.destination=demo1.randomstring
 
-
 spring.ibmmq.host=172.17.0.2
 spring.ibmmq.port=1414
 spring.ibmmq.qm=QM1
@@ -12,15 +11,14 @@ spring.ibmmq.username=scs
 spring.ibmmq.password=scs
 spring.ibmmq.channel=SPRING.JMS.SVRCONN
 
-
 spring.cloud.stream.ibmmq.binder.default-destination-type=topic
 
 # partition the topic using the suffix index in the produced messages
-spring.cloud.stream.bindings.output.producer.partitionKeyExpression=T(java.lang.Integer).parseInt(payload.substring(17))
-spring.cloud.stream.bindings.output.producer.partitionCount=5
+#spring.cloud.stream.bindings.output.producer.partitionKeyExpression=T(java.lang.Integer).parseInt(payload.substring(17))
+#spring.cloud.stream.bindings.output.producer.partitionCount=5
 
-spring.cloud.stream.bindings.output.producer.required-groups[0]=group1
-spring.cloud.stream.bindings.output.producer.required-groups[1]=group2
+#spring.cloud.stream.bindings.output.producer.required-groups[0]=group1
+#spring.cloud.stream.bindings.output.producer.required-groups[1]=group2
 
 
 

--- a/demos/demo-sender/src/main/resources/log4j.properties
+++ b/demos/demo-sender/src/main/resources/log4j.properties
@@ -1,9 +1,0 @@
-#
-# Copyright (C) 2016 TopCoder Inc., All Rights Reserved
-#
-
-log4j.rootLogger=DEBUG, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %m %n

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>Brooklyn.RC1</version>
+                <version>Brooklyn.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -99,15 +99,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/libs-milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>1.1.1.RELEASE</version>
+        <version>1.2.0.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -20,18 +20,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <java.version>1.8</java.version>
-        <jdk.version>1.8</jdk.version>
-        <spring.version>4.2.7.RELEASE</spring.version>
-        <spring-boot.version>1.3.6.RELEASE</spring-boot.version>
         <checkstyle.config.location>checks.xml</checkstyle.config.location>
-        <com.ibm.mq.version>8.0.0.4</com.ibm.mq.version>
-        <mockrunner.version>1.1.1</mockrunner.version>
-        <mockito.version>1.10.19</mockito.version>
+
+        <java.version>1.8</java.version>
+        <spring.version>4.2.7.RELEASE</spring.version>
+        <com.ibm.mq.version>8.0.0.3</com.ibm.mq.version>
         <guava.version>19.0</guava.version>
-        <hamcrest.version>1.3</hamcrest.version>
         <jms.version>2.0.1</jms.version>
-        <assertj.version>1.0.0m1</assertj.version>
+        <assertj.version>3.5.2</assertj.version>
     </properties>
 
     <dependencyManagement>
@@ -39,7 +35,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>1.1.0.BUILD-SNAPSHOT</version>
+                <version>Brooklyn.RC1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -58,49 +54,23 @@
                 <artifactId>spring-integration-jms</artifactId>
                 <version>${spring.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.mockrunner</groupId>
-                <artifactId>mockrunner-jms</artifactId>
-                <version>${mockrunner.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core-java8</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>javax.jms</groupId>
                 <artifactId>javax.jms-api</artifactId>
                 <version>${jms.version}</version>
             </dependency>
+
+            <!-- Test -->
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-test</artifactId>
-                <scope>test</scope>
-                <version>${spring-boot.version}</version>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
             </dependency>
-
-
         </dependencies>
     </dependencyManagement>
 
@@ -126,82 +96,18 @@
                         </dependency>
                     </dependencies>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
     </build>
 
-    <profiles>
-        <profile>
-            <id>spring</id>
-            <repositories>
-                <repository>
-                    <id>spring-snapshots</id>
-                    <name>Spring Snapshots</name>
-                    <url>http://repo.spring.io/libs-snapshot-local</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                </repository>
-                <repository>
-                    <id>spring-milestones</id>
-                    <name>Spring Milestones</name>
-                    <url>http://repo.spring.io/libs-milestone-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>spring-releases</id>
-                    <name>Spring Releases</name>
-                    <url>http://repo.spring.io/release</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>spring-snapshots</id>
-                    <name>Spring Snapshots</name>
-                    <url>http://repo.spring.io/libs-snapshot-local</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>spring-milestones</id>
-                    <name>Spring Milestones</name>
-                    <url>http://repo.spring.io/libs-milestone-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>spring-releases</id>
-                    <name>Spring Releases</name>
-                    <url>http://repo.spring.io/libs-release-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-    </profiles>
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/libs-milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/spring-cloud-starter-stream-ibmmq/pom.xml
+++ b/spring-cloud-starter-stream-ibmmq/pom.xml
@@ -23,22 +23,6 @@
             <artifactId>spring-cloud-stream-binder-ibmmq</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-jmx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/spring-cloud-stream-binder-ibmmq/pom.xml
+++ b/spring-cloud-stream-binder-ibmmq/pom.xml
@@ -16,11 +16,8 @@
 
     <artifactId>spring-cloud-stream-binder-ibmmq</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
-    <dependencies>
 
+    <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
@@ -35,46 +32,13 @@
             <artifactId>spring-cloud-stream-codec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-binder-test</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-test-support-internal</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.ibm</groupId>
             <artifactId>com.ibm.mq.allclient</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-jms</artifactId>
@@ -83,22 +47,18 @@
             <groupId>javax.jms</groupId>
             <artifactId>javax.jms-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.mockrunner</groupId>
-            <artifactId>mockrunner-jms</artifactId>
-        </dependency>
+
+        <!-- Test -->
         <dependency>
             <groupId>org.assertj</groupId>
-            <artifactId>assertj-core-java8</artifactId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
-
-        <!--<dependency>-->
-            <!--<groupId>org.springframework.boot</groupId>-->
-            <!--<artifactId>spring-boot-starter-actuator</artifactId>-->
-            <!--<scope>test</scope>-->
-        <!--</dependency>-->
-
-
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-binder-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/DestinationType.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/DestinationType.java
@@ -11,5 +11,6 @@ package za.co.absa.cloud.stream.binder.ibmmq;
  * @version 1.0
  */
 public enum DestinationType {
+
     TOPIC, QUEUE
 }

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqBaseChannelProperties.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqBaseChannelProperties.java
@@ -13,6 +13,7 @@ import za.co.absa.cloud.stream.binder.ibmmq.DestinationType;
  * @version 1.0
  */
 public class IbmMqBaseChannelProperties {
+
     /**
      * The destination type for this channel.
      */

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqBinderConfigurationProperties.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 import za.co.absa.cloud.stream.binder.ibmmq.DestinationType;
 import za.co.absa.ibmmq.admin.HeaderCompressionTechnique;
@@ -17,13 +16,10 @@ import za.co.absa.ibmmq.admin.MessageCompressionTechnique;
 
 @ConfigurationProperties(prefix = "spring.cloud.stream.ibmmq.binder")
 public class IbmMqBinderConfigurationProperties {
+
     private DestinationType defaultDestinationType = DestinationType.QUEUE;
-
-    private List<MessageCompressionTechnique> msgCompList =
-            new ArrayList<>(Collections.singleton(MessageCompressionTechnique.DEFAULT));
-
-    private List<HeaderCompressionTechnique> hdrCompList =
-            new ArrayList<>(Collections.singleton(HeaderCompressionTechnique.DEFAULT));
+    private List<MessageCompressionTechnique> msgCompList = new ArrayList<>(Collections.singleton(MessageCompressionTechnique.DEFAULT));
+    private List<HeaderCompressionTechnique> hdrCompList = new ArrayList<>(Collections.singleton(HeaderCompressionTechnique.DEFAULT));
 
     /**
      * Get msgCompList

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqExtendedBindingProperties.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqExtendedBindingProperties.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.binder.ExtendedBindingProperties;
-import org.springframework.stereotype.Component;
 
 @ConfigurationProperties("spring.cloud.stream.ibmmq")
 public class IbmMqExtendedBindingProperties

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/cloud/stream/binder/ibmmq/config/IbmMqMessageChannelBinderConfiguration.java
@@ -5,7 +5,6 @@
 package za.co.absa.cloud.stream.binder.ibmmq.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
@@ -33,9 +32,9 @@ import za.co.absa.ibmmq.admin.commands.InquireTopicCommand;
  * @version 1.0
  */
 @Configuration
-@Import({PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class })
+@Import({PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
 @EnableConfigurationProperties({IbmMqProperties.class, IbmMqBinderConfigurationProperties.class,
-    IbmMqExtendedBindingProperties.class })
+        IbmMqExtendedBindingProperties.class})
 public class IbmMqMessageChannelBinderConfiguration {
 
     @Autowired

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/IbmMqException.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/IbmMqException.java
@@ -11,6 +11,7 @@ package za.co.absa.ibmmq;
  * @version 1.0
  */
 public class IbmMqException extends Exception {
+
     /**
      * Constructs instance from message.
      *

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqAdmin.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqAdmin.java
@@ -8,6 +8,9 @@ import java.util.Optional;
 
 import org.springframework.util.Assert;
 
+import com.ibm.mq.MQQueue;
+import com.ibm.mq.MQTopic;
+
 import za.co.absa.ibmmq.IbmMqException;
 import za.co.absa.ibmmq.admin.commands.Command;
 import za.co.absa.ibmmq.admin.commands.CreateQueueCommand;
@@ -16,9 +19,6 @@ import za.co.absa.ibmmq.admin.commands.CreateTopicCommand;
 import za.co.absa.ibmmq.admin.commands.InquireQueueCommand;
 import za.co.absa.ibmmq.admin.commands.InquireTopicCommand;
 
-import com.ibm.mq.MQQueue;
-import com.ibm.mq.MQTopic;
-
 /**
  * A Facade for executing commands against IBM MQ to perform scenarios like get or create queue/topic.
  *
@@ -26,16 +26,12 @@ import com.ibm.mq.MQTopic;
  * @version 1.0
  */
 public class IbmMqAdmin {
+
     private Command<MQQueue, InquireQueueCommand.Params> inquireQueueCommand;
-
     private Command<MQQueue, CreateQueueCommand.Params> createQueueCommand;
-
     private Command<MQTopic, InquireTopicCommand.Params> inquireTopicCommand;
-
     private Command<MQTopic, CreateTopicCommand.Params> createTopicCommand;
-
     private Command<Void, CreateSubscriptionCommand.Params> createSubscriptionCommand;
-
 
     /**
      * Gets the MQQueue instance for the given queue name.
@@ -204,7 +200,7 @@ public class IbmMqAdmin {
      *            the new value.
      */
     public void setCreateSubscriptionCommand(
-        final Command<Void, CreateSubscriptionCommand.Params> createSubscriptionCommand) {
+            final Command<Void, CreateSubscriptionCommand.Params> createSubscriptionCommand) {
         this.createSubscriptionCommand = createSubscriptionCommand;
     }
 
@@ -226,6 +222,4 @@ public class IbmMqAdmin {
     public void setInquireQueueCommand(final Command<MQQueue, InquireQueueCommand.Params> inquireQueueCommand) {
         this.inquireQueueCommand = inquireQueueCommand;
     }
-
-
 }

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqConnectionManager.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqConnectionManager.java
@@ -10,15 +10,15 @@ import javax.annotation.PostConstruct;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 
-import za.co.absa.cloud.stream.binder.ibmmq.config.IbmMqBinderConfigurationProperties;
-import za.co.absa.ibmmq.IbmMqException;
-
 import com.ibm.mq.MQEnvironment;
 import com.ibm.mq.MQException;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.jms.MQConnectionFactory;
 import com.ibm.msg.client.wmq.WMQConstants;
+
+import za.co.absa.cloud.stream.binder.ibmmq.config.IbmMqBinderConfigurationProperties;
+import za.co.absa.ibmmq.IbmMqException;
 
 /**
  * Manages the connections to IBM MQ, it will handle both JMS connection and Native (Queue Manager) connections.
@@ -27,8 +27,8 @@ import com.ibm.msg.client.wmq.WMQConstants;
  * @version 1.0
  */
 public class IbmMqConnectionManager {
-    private IbmMqProperties ibmMqProperties;
 
+    private IbmMqProperties ibmMqProperties;
     private IbmMqBinderConfigurationProperties ibmMqBinderProperties;
 
     private volatile MQConnectionFactory jmsConnectionFactory;
@@ -129,7 +129,6 @@ public class IbmMqConnectionManager {
         }
     }
 
-
     /**
      * Get ibmMqProperties
      *
@@ -142,7 +141,8 @@ public class IbmMqConnectionManager {
     /**
      * Set ibmMqProperties
      *
-     * @param ibmMqProperties the new value.
+     * @param ibmMqProperties
+     *            the new value.
      */
     public void setIbmMqProperties(final IbmMqProperties ibmMqProperties) {
         this.ibmMqProperties = ibmMqProperties;
@@ -160,7 +160,8 @@ public class IbmMqConnectionManager {
     /**
      * Set ibmMqBinderProperties
      *
-     * @param ibmMqBinderProperties the new value.
+     * @param ibmMqBinderProperties
+     *            the new value.
      */
     public void setIbmMqBinderProperties(final IbmMqBinderConfigurationProperties ibmMqBinderProperties) {
         this.ibmMqBinderProperties = ibmMqBinderProperties;

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqNativeClient.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqNativeClient.java
@@ -4,14 +4,11 @@
 
 package za.co.absa.ibmmq.admin;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import za.co.absa.ibmmq.IbmMqException;
-
 import com.ibm.mq.MQException;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.pcf.PCFMessageAgent;
+
+import za.co.absa.ibmmq.IbmMqException;
 
 /**
  * A wrapper for MQQueueManager and PCFMessageAgent.
@@ -20,10 +17,10 @@ import com.ibm.mq.pcf.PCFMessageAgent;
  * @version 1.0
  */
 public class IbmMqNativeClient {
+
     private IbmMqConnectionManager ibmMqConnectionManager;
 
     private volatile MQQueueManager queueManager;
-
     private volatile PCFMessageAgent pcfMessageAgent;
 
     public MQQueueManager getQueueManager() throws IbmMqException {
@@ -68,9 +65,10 @@ public class IbmMqNativeClient {
     /**
      * Set ibmMqConnectionManager
      *
-     * @param ibmMqConnectionManager the new value.
+     * @param ibmMqConnectionManager
+     *            the new value.
      */
-    public void setIbmMqConnectionManager(IbmMqConnectionManager ibmMqConnectionManager) {
+    public void setIbmMqConnectionManager(final IbmMqConnectionManager ibmMqConnectionManager) {
         this.ibmMqConnectionManager = ibmMqConnectionManager;
     }
 

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqProperties.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/IbmMqProperties.java
@@ -5,7 +5,6 @@
 package za.co.absa.ibmmq.admin;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 /**
  * The basic connectivity and security properties for IBM MQ
@@ -15,6 +14,7 @@ import org.springframework.stereotype.Component;
  */
 @ConfigurationProperties(prefix = "spring.ibmmq")
 public class IbmMqProperties {
+
     private String host = "127.0.0.1";
     private Integer port = 1414;
     private String qm = "QM1";

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/BasePcfCommand.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/BasePcfCommand.java
@@ -8,12 +8,12 @@ import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import za.co.absa.ibmmq.IbmMqException;
-import za.co.absa.ibmmq.admin.IbmMqNativeClient;
-
 import com.ibm.mq.MQException;
 import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.pcf.PCFMessage;
+
+import za.co.absa.ibmmq.IbmMqException;
+import za.co.absa.ibmmq.admin.IbmMqNativeClient;
 
 /**
  * Base class for all PCF Commands.
@@ -22,6 +22,7 @@ import com.ibm.mq.pcf.PCFMessage;
  * @version 1.0
  */
 public abstract class BasePcfCommand<T, P extends BasePcfCommand.Params> implements Command<T, P> {
+
     @Autowired
     private IbmMqNativeClient ibmMqNativeClient;
 

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/Command.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/Command.java
@@ -18,6 +18,7 @@ import za.co.absa.ibmmq.IbmMqException;
  *            the parameters type that will be passed the the execute method
  */
 public interface Command<T, P extends Command.Params> {
+
     /**
      * Executes this commands.
      *

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/CreateQueueCommand.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/CreateQueueCommand.java
@@ -4,16 +4,14 @@
 
 package za.co.absa.ibmmq.admin.commands;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-
-import za.co.absa.ibmmq.IbmMqException;
-import za.co.absa.ibmmq.admin.IbmMqProperties;
 
 import com.ibm.mq.MQQueue;
 import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.pcf.PCFMessage;
+
+import za.co.absa.ibmmq.IbmMqException;
+import za.co.absa.ibmmq.admin.IbmMqProperties;
 
 /**
  * a PCF command that will creates a local IBM MQ Queue and returns an instance of MQQueue for the created queue.
@@ -24,7 +22,6 @@ import com.ibm.mq.pcf.PCFMessage;
 public class CreateQueueCommand extends BasePcfCommand<MQQueue, CreateQueueCommand.Params> {
 
     private IbmMqProperties ibmMqProperties;
-
     private InquireQueueCommand inquireQueueCommand;
 
     /**
@@ -123,18 +120,20 @@ public class CreateQueueCommand extends BasePcfCommand<MQQueue, CreateQueueComma
     /**
      * Set ibmMqProperties
      *
-     * @param ibmMqProperties the new value.
+     * @param ibmMqProperties
+     *            the new value.
      */
-    public void setIbmMqProperties(IbmMqProperties ibmMqProperties) {
+    public void setIbmMqProperties(final IbmMqProperties ibmMqProperties) {
         this.ibmMqProperties = ibmMqProperties;
     }
 
     /**
      * Set inquireQueueCommand
      *
-     * @param inquireQueueCommand the new value.
+     * @param inquireQueueCommand
+     *            the new value.
      */
-    public void setInquireQueueCommand(InquireQueueCommand inquireQueueCommand) {
+    public void setInquireQueueCommand(final InquireQueueCommand inquireQueueCommand) {
         this.inquireQueueCommand = inquireQueueCommand;
     }
 

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/CreateSubscriptionCommand.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/CreateSubscriptionCommand.java
@@ -4,13 +4,12 @@
 
 package za.co.absa.ibmmq.admin.commands;
 
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-
-import za.co.absa.ibmmq.IbmMqException;
 
 import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.pcf.PCFMessage;
+
+import za.co.absa.ibmmq.IbmMqException;
 
 /**
  * a PCF command to create a subscription.

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/CreateTopicCommand.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/CreateTopicCommand.java
@@ -4,15 +4,13 @@
 
 package za.co.absa.ibmmq.admin.commands;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-
-import za.co.absa.ibmmq.IbmMqException;
 
 import com.ibm.mq.MQTopic;
 import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.pcf.PCFMessage;
+
+import za.co.absa.ibmmq.IbmMqException;
 
 /**
  * a PCF Command to create a IBM MQ Topic and returns an instance of MQTopic for the created topic.
@@ -113,9 +111,10 @@ public class CreateTopicCommand extends BasePcfCommand<MQTopic, CreateTopicComma
     /**
      * Set inquireTopicCommand
      *
-     * @param inquireTopicCommand the new value.
+     * @param inquireTopicCommand
+     *            the new value.
      */
-    public void setInquireTopicCommand(InquireTopicCommand inquireTopicCommand) {
+    public void setInquireTopicCommand(final InquireTopicCommand inquireTopicCommand) {
         this.inquireTopicCommand = inquireTopicCommand;
     }
 

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/InquireQueueCommand.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/InquireQueueCommand.java
@@ -4,17 +4,15 @@
 
 package za.co.absa.ibmmq.admin.commands;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-
-import za.co.absa.ibmmq.IbmMqException;
-import za.co.absa.ibmmq.admin.IbmMqNativeClient;
 
 import com.ibm.mq.MQException;
 import com.ibm.mq.MQQueue;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.MQConstants;
+
+import za.co.absa.ibmmq.IbmMqException;
+import za.co.absa.ibmmq.admin.IbmMqNativeClient;
 
 /**
  * A Simple Command That will retrieve an instance of the configure queue if exist or null otherwise.
@@ -23,6 +21,7 @@ import com.ibm.mq.constants.MQConstants;
  * @version 1.0
  */
 public class InquireQueueCommand implements Command<MQQueue, InquireQueueCommand.Params> {
+
     private IbmMqNativeClient ibmMqNativeClient;
 
     /**
@@ -48,8 +47,6 @@ public class InquireQueueCommand implements Command<MQQueue, InquireQueueCommand
             }
         }
     }
-
-
 
     /**
      * Creates a new Params instance for this command.
@@ -107,9 +104,10 @@ public class InquireQueueCommand implements Command<MQQueue, InquireQueueCommand
     /**
      * Set ibmMqNativeClient
      *
-     * @param ibmMqNativeClient the new value.
+     * @param ibmMqNativeClient
+     *            the new value.
      */
-    public void setIbmMqNativeClient(IbmMqNativeClient ibmMqNativeClient) {
+    public void setIbmMqNativeClient(final IbmMqNativeClient ibmMqNativeClient) {
         this.ibmMqNativeClient = ibmMqNativeClient;
     }
 

--- a/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/InquireTopicCommand.java
+++ b/spring-cloud-stream-binder-ibmmq/src/main/java/za/co/absa/ibmmq/admin/commands/InquireTopicCommand.java
@@ -4,16 +4,14 @@
 
 package za.co.absa.ibmmq.admin.commands;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-
-import za.co.absa.ibmmq.IbmMqException;
-import za.co.absa.ibmmq.admin.IbmMqNativeClient;
 
 import com.ibm.mq.MQException;
 import com.ibm.mq.MQTopic;
 import com.ibm.mq.constants.MQConstants;
+
+import za.co.absa.ibmmq.IbmMqException;
+import za.co.absa.ibmmq.admin.IbmMqNativeClient;
 
 /**
  * A Simple Command That will retrieve an instance of the configure topic if exist or null otherwise.
@@ -22,6 +20,7 @@ import com.ibm.mq.constants.MQConstants;
  * @version 1.0
  */
 public class InquireTopicCommand implements Command<MQTopic, InquireTopicCommand.Params> {
+
     private IbmMqNativeClient ibmMqNativeClient;
 
     /**
@@ -106,9 +105,10 @@ public class InquireTopicCommand implements Command<MQTopic, InquireTopicCommand
     /**
      * Set ibmMqNativeClient
      *
-     * @param ibmMqNativeClient the new value.
+     * @param ibmMqNativeClient
+     *            the new value.
      */
-    public void setIbmMqNativeClient(IbmMqNativeClient ibmMqNativeClient) {
+    public void setIbmMqNativeClient(final IbmMqNativeClient ibmMqNativeClient) {
         this.ibmMqNativeClient = ibmMqNativeClient;
     }
 

--- a/spring-cloud-stream-binder-ibmmq/src/test/java/za/co/absa/cloud/stream/binder/ibmmq/IbmMqBinderTopicProducerTest.java
+++ b/spring-cloud-stream-binder-ibmmq/src/test/java/za/co/absa/cloud/stream/binder/ibmmq/IbmMqBinderTopicProducerTest.java
@@ -4,18 +4,9 @@
 
 package za.co.absa.cloud.stream.binder.ibmmq;
 
-import java.util.Date;
-
 import org.junit.Test;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.integration.annotation.InboundChannelAdapter;
-import org.springframework.integration.core.MessageSource;
-import org.springframework.messaging.support.GenericMessage;
 
 /**
  * Test the binder with a producer application and with Topic destination.

--- a/spring-cloud-stream-binder-ibmmq/src/test/java/za/co/absa/cloud/stream/binder/ibmmq/IbmMqMessageChannelBinderBaseTest.java
+++ b/spring-cloud-stream-binder-ibmmq/src/test/java/za/co/absa/cloud/stream/binder/ibmmq/IbmMqMessageChannelBinderBaseTest.java
@@ -4,7 +4,7 @@
 
 package za.co.absa.cloud.stream.binder.ibmmq;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Date;

--- a/spring-cloud-stream-binder-ibmmq/src/test/resources/application.properties
+++ b/spring-cloud-stream-binder-ibmmq/src/test/resources/application.properties
@@ -4,14 +4,12 @@
 
 #spring.cloud.stream.bindings.output.destination=demo1.randomstring
 
-
 spring.ibmmq.host=172.17.0.2
 spring.ibmmq.port=1414
 spring.ibmmq.qm=QM1
 spring.ibmmq.username=scs
 spring.ibmmq.password=scs
 spring.ibmmq.channel=SPRING.JMS.SVRCONN
-
 
 #spring.cloud.stream.ibmmq.binder.default-destination-type=topic
 #


### PR DESCRIPTION
Upgrade to Spring 1.4.0.
Removed unused dependencies (demo apps tested in non partitioned default test).
Fixed all Checkstyle violations.
Verified all tests run successfully using MQ 8 Docker container.
Defaulted the demo apps to not be partitioned, to facilitate easier default testing.
